### PR TITLE
Changes, additions and fixing.

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
 </style></head>
 
 <body>
-	<div id="filename_temp" style="display:none;" title="This is temp div for saving here a file name if file was been loaded by input."></div>
+	<div id="filename_temp" style="display:none;" title="This is temp div for saving here a file name if file was been loaded by input.">filename.txt</div>
     <!--status notification-->
     <div class="hidden">
         <div class="alert alert-success fade in" id="vrSuccess">
@@ -291,7 +291,7 @@
                                         </div>
                                         <div id="vrAlert"></div>
                                         <div class="panel-body">
-                                            <textarea class="form-control message" rows="7" id="pure-text" placeholder="Here you'll see the raw message, if signed it will be verified." readonly=""></textarea>
+                                            <textarea class="form-control message" rows="7" id="pure-text" placeholder="Here you'll see the raw message, if this signed and will be verified." readonly=""></textarea>
                                             <br>
                                             <a id="download_verified_as_binary" style="display:none; float: right" href="javascript:void(0);"
 											title="If in textarea base64 encoded file content - you can download this as binary RAW-data.">
@@ -384,7 +384,10 @@
                                             <h3 class="panel-title">Receiver's Private Key (decryption)</h3>
                                         </div>
                                         <div class="panel-body">
-                                            <textarea class="form-control message" id="decryption-private-key" rows="7" placeholder="Paste the private key here to decrypt. RSA key only."></textarea>
+                                            <textarea class="form-control message" id="decryption-private-key" rows="7" placeholder="Paste the private key here to decrypt. RSA key only."
+title="If you want to check signature only, without decrypt.
+Paste here some another private key and signer's pub in next field.
+Or paste here priv, which correspoding the signer's pub, without filling next field."></textarea>
                                             <input type='file' onchange='openFile(event, "decryption-private-key")'><br>
                                             <br>
 
@@ -399,7 +402,7 @@
                                           <h3 class="panel-title">Signer's Public Key</h3>
                                       </div>
                                       <div class="panel-body">
-                                          <textarea class="form-control message" id="signer_public_key" rows="7" placeholder="Paste the signer's public key here if the message is signed. This can be ECC key." title="Or leave this field empty, if message is without signature."></textarea>
+                                          <textarea class="form-control message" id="signer_public_key" rows="7" placeholder="Paste the signer's public key here, if the message is signed. This can be ECC key." title="Or leave this field empty, if message is without signature."></textarea>
                                           <input type='file' onchange='openFile(event, "signer_public_key")'><br>
                                           <br>
                                       </div>

--- a/index_files/js/main.js
+++ b/index_files/js/main.js
@@ -26,7 +26,7 @@ var openFile = function(event, id, as_base64) {
 		};
 		
 		if(input.files[0]===undefined){
-			document.getElementById('filename_temp').innerHTML = '';
+			document.getElementById('filename_temp').innerHTML = 'filename.txt';
 		}
 		else{
 			//set file name as temporary text in invisible div
@@ -35,7 +35,7 @@ var openFile = function(event, id, as_base64) {
 		
 		if(as_base64==='as_base64'){
 			reader.readAsDataURL(input.files[0]);
-			document.getElementById("filename_temp").innerHTML +='.base64'
+			document.getElementById("filename_temp").innerHTML +='.base64.txt'
 		}else{
 			reader.readAsText(input.files[0]);
 		}
@@ -67,14 +67,14 @@ function linkText(input, link, action, as_binary) { //IDs and filename
 	
 	if(as_binary===undefined){
 		if(isBase64(input.value)){
-			if(filename_temp.indexOf('.base64')==-1){
-				filename_temp = filename_temp+'.base64';
+			if(filename_temp.indexOf('.base64.txt')==-1){
+				filename_temp = filename_temp+'.base64.txt';
 			}
 		}
 	}
 	else{
-		if(isBase64(input.value) && filename_temp.indexOf('.base64')!=-1){
-			filename_temp = filename_temp.replace('.base64','');
+		if(isBase64(input.value) && filename_temp.indexOf('.base64.txt')!=-1){
+			filename_temp = filename_temp.replace('.base64.txt','');
 		}
 	}
 
@@ -90,7 +90,11 @@ function linkText(input, link, action, as_binary) { //IDs and filename
 function updateLink(input, link, as_binary, action) { //
   link.hidden = !input.value;
 	if(as_binary==='as_binary'){
-		link.href = "data:application/octet-stream;base64," + encodeURI(input.value); //<-- base64 as binary
+		if(isBase64(input.value)){
+			link.href = "data:application/octet-stream;base64," + encodeURI(input.value); //<-- base64 as binary
+		}else{
+			link.href = "data:application/octet-stream;charset=utf-8," + encodeURI(input.value); //<-- base64 as binary
+		}
 	}
 	else{
 		link.href = "data:text/plain;charset=UTF-8," + encodeURI(input.value); //<-- data in href
@@ -100,29 +104,70 @@ function updateLink(input, link, as_binary, action) { //
   
 	if(action==='sign'){
 		var suffix = 'signed';
-		link.download = (filename_temp==='') ? "text"+'.'+suffix+'.txt' : filename_temp+'.'+suffix+'.txt';
+		link.download = filename_temp+'.'+suffix+'.txt';
 	}else if(action==='verify'){
-		var suffix = 'verified'
-		link.download = (filename_temp.indexOf('.signed.txt')!==1) ? filename_temp.replace('.signed.txt',''): "pure_text"+'.txt';
+		var suffix = 'verified';
+		
+		link.download = //multistring ternary operator
+			(filename_temp.indexOf('.signed')===-1) //if true
+			?(as_binary==='as_binary') 					//check this
+				? (isBase64(input.value))					//then check this
+					?"Raw_code"+'.txt' 						//if true
+					:"Raw_code"+'.bin.txt' 					//if false
+				: (isBase64(input.value))				//if previous false, check this
+					?"Raw_code"+'.base64.txt' 				//if true
+					:"Raw_code"+'.txt' 						//if false
+			: filename_temp.split('.signed', 1)[0]; //if first - false, do this
+
 	}else if(action==='encrypt'){
 		var suffix = 'encryted';
-		link.download = (filename_temp==='') ? "text"+'.encrypted.txt' : filename_temp+'.encrypted.txt';
+		link.download = filename_temp+'.encrypted.txt';
 	}else if(action==='decrypt'){
 		var suffix = 'decrypted';
-		link.download = (filename_temp.indexOf('.encrypted.txt')!==1) ? filename_temp.replace('.encrypted.txt',''):"pure_text"+'.txt';
+		
+		link.download =
+			(filename_temp.indexOf('.encrypted')===-1)
+			?(as_binary==='as_binary')
+				? (isBase64(input.value))
+					?"Raw_code"+'.txt'
+					:"Raw_code"+'.bin.txt'
+				: (isBase64(input.value))
+					?"Raw_code"+'.base64.txt'
+					:"Raw_code"+'.txt'
+			: filename_temp.split('.encrypted', 1)[0];
+
 	}else if(action==='sign+encrypt'){
 		var suffix = 'signed and encrypted';
-		link.download = (filename_temp==='') ? "text"+'.encrypted_and_signed.txt' : filename_temp+'.encrypted_and_signed.txt';
+		link.download = filename_temp+'.encrypted_and_signed.txt';
 	}else if(action==='decrypt+verify'){
 		var suffix = 'decrypted and verified';
-		link.download = (filename_temp.indexOf('.encrypted_and_signed.txt')!==1) ? filename_temp.replace('.encrypted_and_signed.txt','') : "pure_text"+'.txt';
+		
+		link.download =
+			(filename_temp.indexOf('.encrypted_and_signed')===-1)
+			?(filename_temp.indexOf('.signed')===-1)
+				?(as_binary==='as_binary')
+					? (isBase64(input.value))
+						?"Raw_code"+'.txt'
+						:"Raw_code"+'.bin.txt'
+					: (isBase64(input.value))
+						?"Raw_code"+'.base64.txt'
+						:"Raw_code"+'.txt'
+				: filename_temp.split('.signed', 1)[0]
+			: filename_temp.split('.encrypted_and_signed.txt', 1)[0];
 	}
 	
+	var filename_notify = 'Filename is: '+link.getAttribute("download")+'\n'+
+		'To change filename, load file again and re-sign the message,\n'+
+		'or try to load another file, then do cansel loading this.';
+		
 	if(as_binary===undefined){
-		link.setAttribute('title', 'Download '+suffix+' message as text');
+		link.setAttribute('title', 'Download '+suffix+' message as text. \n\n'+
+		filename_notify
+		);
 	}else{
-		link.setAttribute('title', 'Download '+suffix+' message as binary.\n'+
-		'If in textarea base64 encoded file content - you can download this as binary RAW-data.'
+		link.setAttribute('title', 'Download '+suffix+' message as binary. \n'+
+		'If in textarea base64 encoded file content - you can download this as binary RAW-data.\n\n'+
+		filename_notify
 		);
 	}
 }
@@ -173,9 +218,9 @@ $(document).ready(function() {
 		$(this).removeAttr("readonly");
 	});
 	
-	
-	
 
+	
+	
     // SIGN
     var signButton = $("#sign-button");
 
@@ -255,15 +300,23 @@ $(document).ready(function() {
                   var ring = new kbpgp.keyring.KeyRing;
                   ring.add_key_manager(receiver);
 				  
+				  console.log('verify function, key-ring...', ring); //<-- "key is found here."
+
 				  kbpgp.unbox({keyfetch: ring, armored: UnverifiedPlainText.val()}, function(err, literals) {
                     if (err != null) {
 						//here is error if message was been encrypted by RSA public key,
 						//but signed by ECC private key.
-						clone.find('#vrAddrLabel').html("Message failed to verify! "+err);
+						
+						//this message means, that "key is found here." not found.
+						//this means keyfetch: ring not working correctly.
+						//Also, this means that maybe, signing is not doing by ECC private key, and doing by RSA pub, or both...
+						
+						clone.find('#vrAddrLabel').html("Message failed to verify! See console.log (F12-button)"+err);
+						clone.appendTo($('#vrAlert'));
                       return console.log("Problem: " + err);
                     } else {
                       var text = literals[0].toString();
-                      console.log("decrypted message: " + text);
+                      console.log("Clear-sig, message without signature: " + text);
 
                       PureText.val(text);
 					  linkText(document.getElementById('pure-text'), document.getElementById('download-pure-text'), 'verify');
@@ -300,6 +353,7 @@ $(document).ready(function() {
   var signencryptButton = $("#signencrypt-button");
 
   signencryptButton.click(function() {
+		//encrypt by pub, then sign by priv
       var signencryptPlainText = $("#signencrypt-plain-text");
       var signencryptText = $("#signencrypt-text");
       var signencryptPrivateKey = $("#signencrypt-private-key");
@@ -371,13 +425,13 @@ $(document).ready(function() {
     var decryptionButton = $("#decryption-button");
 
     decryptionButton.click(function(){
+		//first, verify signature by pub, then decrypt by priv.
         var decryptionEncryptedText = $("#decryption-encrypted-text");
         var decryptionDecryptedText = $("#decryption-decrypted-text");
         var decryptionPrivateKey = $("#decryption-private-key");
         var decryptionPassphrase = $("#decryption-passphrase");
-        var PubSigVerify = $("#signer_public_key");
-
-        
+        var PubSigVerify = $("#signer_public_key");		
+		
 		//console.log(decryptionEncryptedText);
 
         $('#vrAlert2').empty();
@@ -397,6 +451,7 @@ $(document).ready(function() {
 
                   // add KeyRing
                   var ring = new kbpgp.keyring.KeyRing;
+				  console.log('ring', ring);
                   ring.add_key_manager(currUser);
 					var senderPUB = kbpgp.KeyManager.import_from_armored_pgp
 					(
@@ -420,17 +475,6 @@ $(document).ready(function() {
 
 										decryptionDecryptedText.val(decryptedText);
 										
-										linkText(
-											document.getElementById('decryption-decrypted-text'),
-											document.getElementById('download-decrypted-text'),
-											'decrypt+verify'
-										);
-										linkText(
-											document.getElementById('decryption-decrypted-text'),
-											document.getElementById('download_decrypt_verify_as_binary'),
-											'decrypt+verify', 'as_binary'
-										);
-										
 										var ds = km = null;
 										ds = literals[0].get_data_signer();
 										if (ds) { km = ds.get_key_manager(); }
@@ -449,10 +493,32 @@ $(document).ready(function() {
 												clone = $('#vrWarning').clone();
 												clone.find('#vrAddrLabel').html("Incorrect fingerprint "+pub_f);
 											}
+											
+											linkText(
+												document.getElementById('decryption-decrypted-text'),
+												document.getElementById('download-decrypted-text'),
+												'decrypt+verify'
+											);
+											linkText(
+												document.getElementById('decryption-decrypted-text'),
+												document.getElementById('download_decrypt_verify_as_binary'),
+												'decrypt+verify', 'as_binary'
+											);
 						
 										}else{
 											clone = $('#vrWarning').clone();
 											clone.find('#vrAddrLabel').html('Decrypted, but incorrect fingerprint - signature not verified.<br>If this message encrypted without signature - ignore this message.');
+											
+											linkText(
+												document.getElementById('decryption-decrypted-text'),
+												document.getElementById('download-decrypted-text'),
+												'decrypt'
+											);
+											linkText(
+												document.getElementById('decryption-decrypted-text'),
+												document.getElementById('download_decrypt_verify_as_binary'),
+												'decrypt', 'as_binary'
+											);
 										}
 										clone.appendTo($('#vrAlert2')); //display alert message
 									}
@@ -462,7 +528,50 @@ $(document).ready(function() {
 								kbpgp.unbox({keyfetch: ring, armored: decryptionEncryptedText.val()}, function(err, literals)
 								{
 									if (err != null) {
-										clone.find('#vrAddrLabel').html("Message failed to verify! <br>"+ err);
+										//message decrypted, but signature not verified.
+										//decryption-decrypted-text - id for textarea
+										
+										//maybe this is signed text (if (sign+)encrypt -> decrypt(+verify) ) - but no, this is the same message.
+										//console.log('decryptionEncryptedText.val();', decryptionEncryptedText.val());
+										
+										//Add this from hidden textarea:
+										//document.getElementById('decryption-decrypted-text').value = decryptionEncryptedText.val();
+										//document.getElementById('decryption-decrypted-text').setAttribute('title', 'This is decrypted message, but signature not verified.');
+
+										//run functions to generate download links.
+										/*
+										linkText(
+												document.getElementById('decryption-decrypted-text'),
+												document.getElementById('download-decrypted-text'),
+												'decrypt'
+										);
+										linkText(
+											document.getElementById('decryption-decrypted-text'),
+											document.getElementById('download_decrypt_verify_as_binary'),
+											'decrypt', 'as_binary'
+										);
+										
+										//This may be signed pgp message, encrypted by pub,
+										//and this message may be can be decrypted by priv.
+										//But... Incorrect fingerprint.
+										
+										//https://smartninja-pgp.appspot.com/
+										//SmartNinja cann't decrypt this, incorrect key error in console + HHHAAASSSHHH.
+										
+										//This trying for decryption was been doing,
+										//after re-encrypt the message, by RSA key, generated on smartninja generator,
+										//+SIGN by ECC private key from PGP suite generator.
+										//Smartninja cann't do encrypt the message, using RSA keys, generated on PGP Suite.
+										//Need fix this incompatibility.
+										
+										//HHHAAASSSHHH in error - corresponding the ECC key
+										//if ring will be displayed in console.log
+										//Maybe there need to fix keyring, keybox, and fetch functions.
+										*/
+										
+										
+										//just display an error, without any message...
+										clone.find('#vrAddrLabel').html("this... Message failed to verify! <br>"+ err);
 										clone.appendTo($('#vrAlert2'));
 										console.log(err);
 									} else
@@ -472,23 +581,16 @@ $(document).ready(function() {
 
 										decryptionDecryptedText.val(decryptedText);
 										
-										linkText(
-											document.getElementById('decryption-decrypted-text'),
-											document.getElementById('download-decrypted-text'),
-											'decrypt'
-										);
-										linkText(
-											document.getElementById('decryption-decrypted-text'),
-											document.getElementById('download_decrypt_verify_as_binary'),
-											'decrypt', 'as_binary'
-										);
-										
 										var ds = km = null;
 										ds = literals[0].get_data_signer();
 										if (ds) { km = ds.get_key_manager(); }
 										if (km) {
 											console.log("Signed by PGP fingerprint");
-											var pub_f = senderPUB.get_pgp_fingerprint().toString('hex');
+											console.log('senderPUB', senderPUB);
+											var pub_f = (senderPUB===null)
+												? currUser.get_pgp_fingerprint().toString('hex')
+												: senderPUB.get_pgp_fingerprint().toString('hex')
+											
 											var text_f = km.get_pgp_fingerprint().toString('hex');
 											console.log(text_f, (pub_f===text_f) ? 'and verified.' : 'and failed to verify.');
 											
@@ -501,10 +603,32 @@ $(document).ready(function() {
 												clone = $('#vrWarning').clone();
 												clone.find('#vrAddrLabel').html("Incorrect fingerprint "+pub_f);
 											}
+											
+											linkText(
+												document.getElementById('decryption-decrypted-text'),
+												document.getElementById('download-decrypted-text'),
+												'decrypt+verify'
+											);
+											linkText(
+												document.getElementById('decryption-decrypted-text'),
+												document.getElementById('download_decrypt_verify_as_binary'),
+												'decrypt+verify', 'as_binary'
+											);											
 						
 										}else{
 											clone = $('#vrWarning').clone();
 											clone.find('#vrAddrLabel').html('Decrypted, but incorrect fingerprint - signature not verified.<br>If this message encrypted without signature - ignore this message.');
+											
+											linkText(
+												document.getElementById('decryption-decrypted-text'),
+												document.getElementById('download-decrypted-text'),
+												'decrypt'
+											);
+											linkText(
+												document.getElementById('decryption-decrypted-text'),
+												document.getElementById('download_decrypt_verify_as_binary'),
+												'decrypt', 'as_binary'
+											);
 										}
 										clone.appendTo($('#vrAlert2')); //display alert message
 									}

--- a/index_files/js/main.js
+++ b/index_files/js/main.js
@@ -156,17 +156,15 @@ function updateLink(input, link, as_binary, action) { //
 			: filename_temp.split('.encrypted_and_signed.txt', 1)[0];
 	}
 	
-	var filename_notify = 'Filename is: '+link.getAttribute("download")+'\n'+
-		'To change filename, load file again and re-sign the message,\n'+
-		'or try to load another file, then do cansel loading this.';
-		
+	var filename_notify = 'Filename is: '+link.getAttribute("download");
+
 	if(as_binary===undefined){
-		link.setAttribute('title', 'Download '+suffix+' message as text. \n\n'+
+		link.setAttribute('title', 'Download '+suffix+' message as text. \n'+
 		filename_notify
 		);
 	}else{
 		link.setAttribute('title', 'Download '+suffix+' message as binary. \n'+
-		'If in textarea base64 encoded file content - you can download this as binary RAW-data.\n\n'+
+		'If in textarea base64 encoded file content - you can download this as binary RAW-data.\n'+
 		filename_notify
 		);
 	}


### PR DESCRIPTION
- Add default filename.
- Add functions to working with file-names.
- Add tooltip to the buttons with filename included.
- Add default filename if message input as text.
- Add bin prefix for filenames if this downloading as binary.
- Now base64 encoded files available as txt-files.
- Fix "Message failed to verify" alert notification. If encrypted message try to verify Key not found in this case. If checksum mismatch - alert displayed now.
- Test decryption without check signature, for signed_and_encrypted, and try to got encrypted message after check signature.
	Big commentary in decrypt+verify function added. https://github.com/TheChiefMeat/pgp/issues/7
- Found Generators incompatibility. Just leave this here, as todo note. https://github.com/TheChiefMeat/pgp/issues/8
- Many tests made with different files and keys. There is possible to make Jasmine-test.

Have a nice day.